### PR TITLE
UN-8441 update node to v16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN set -ex \
     && apt-key update && apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
     libxml2-dev libxslt-dev libmysqlclient-dev mysql-client \
     # nodejs
-    && apt-get update && apt-get install -y --no-install-recommends nodejs \
+    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install -y nodejs \
+    && node -v \
     # pwgen
     && apt-get update && apt-get install -y --no-install-recommends pwgen \
     && ln -s /usr/bin/pwgen /bin/pwgen \
@@ -54,4 +56,3 @@ EXPOSE 3000
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-


### PR DESCRIPTION
## What and Why
We want to update Node. v18 doesn't build on our version of ubuntu (xenial), so we're going with v16 unless we want to upgrade ubuntu. 16 is good enough for what we need

## Related Tickets and PRs

Fixes [UN-8441](https://tabbedout.atlassian.net/browse/UN-8441)

## Steps to Test
build the docker image

## Humor for Reviewer

[UN-8441]: https://tabbedout.atlassian.net/browse/UN-8441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ